### PR TITLE
Bug fix to support search with modifier with multiple targets

### DIFF
--- a/lib/RouteFactory/search/query.js
+++ b/lib/RouteFactory/search/query.js
@@ -111,12 +111,13 @@ function makeResourceReferenceValue(targets, field){
             resource = field.key.modifier;
         }
     }
-
-    if (targets.length == 1) {
-        resource = targets[0];
-    }
     else {
-        throw new Error('Unable to determine resource type for this search (:[type] modifier required)');
+        if (targets.length == 1) {
+            resource = targets[0];
+        }
+        else {
+            throw new Error('Unable to determine resource type for this search (:[type] modifier required)');
+        }
     }
 
     return {key: {}, value: {text: resource + '/' + field.value.text}}

--- a/test/spec/RouteFactory/search/query-tests.js
+++ b/test/spec/RouteFactory/search/query-tests.js
@@ -993,6 +993,22 @@ describe('query', function () {
                     }
                 ];
 
+                it('filters by resource type & id when multiple resource type targets defined', function () {
+                    var req = {
+                        query: {
+                            'provider:Practitioner': '456',
+                            'provider:Organization': '789'
+                        }
+                    };
+
+                    var result = query.reduceToOperations(req.query, searchParam2);
+
+                    should.exist(result);
+                    result.match.length.should.equal(2);
+                    result.match[0].should.deep.equal({'resource.managingOrganization.reference': 'Practitioner/456'});
+                    result.match[1].should.deep.equal({'resource.managingOrganization.reference': 'Organization/789'});
+                });                
+
                 it('throws if resource is ambiguous', function () {
                     var req = {
                         query: {


### PR DESCRIPTION
Change makeResourceReferenceValue() so when more than one target is defined, the code doesn't throw an error.
Added spec test to check behaviour - all tests passing.
  